### PR TITLE
Disable deprecation warnings and errors

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -9,7 +9,16 @@ workspace 'immersive'
 
     location 'build/'
 
-    defines { 'PUGIXML_WCHAR_MODE' }
+    defines { 
+        "_CRT_SECURE_NO_WARNINGS",
+        "_CRT_SECURE_NO_DEPRECATE",
+        "_CRT_NONSTDC_NO_WARNINGS",
+        "_CRT_NONSTDC_NO_DEPRECATE",
+        "_SCL_SECURE_NO_WARNINGS",
+        "_SCL_SECURE_NO_DEPRECATE",
+        "_WINSOCK_DEPRECATED_NO_WARNINGS",
+        "PUGIXML_WCHAR_MODE"
+    }
 
     filter 'platforms:Win32'
         architecture 'x32'


### PR DESCRIPTION
Gets rid of those annoying compiler warnings for deprecated functions from win32 API.
